### PR TITLE
Fix installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Make sure go is installed on your system.
 
 Install with:
 ```
-go get github.com/moson-mo/mnserver
+go install github.com/moson-mo/mnserver@latest
 ```
 
 Run with:


### PR DESCRIPTION
"go get" does not seem to be supported anymore
so change instruction to go install and also
add the @latest tag needed by go install.

Signed-off-by: Dan Johansen <strit@manjaro.org>